### PR TITLE
OFS-99: fixing uuid field when the user is anonymous

### DIFF
--- a/contribution_plan/models.py
+++ b/contribution_plan/models.py
@@ -27,7 +27,7 @@ class ContributionPlanBundle(core_models.HistoryBusinessModel):
         if isinstance(user, ResolveInfo):
             user = user.context.user
         if settings.ROW_SECURITY and user.is_anonymous:
-            return queryset.filter(id=-1)
+            return queryset.filter(id=None)
         if settings.ROW_SECURITY:
             pass
         return queryset
@@ -60,7 +60,7 @@ class ContributionPlan(core_models.HistoryBusinessModel):
         if isinstance(user, ResolveInfo):
             user = user.context.user
         if settings.ROW_SECURITY and user.is_anonymous:
-            return queryset.filter(id=-1)
+            return queryset.filter(id=None)
         if settings.ROW_SECURITY:
             pass
         return queryset
@@ -92,7 +92,7 @@ class ContributionPlanBundleDetails(core_models.HistoryBusinessModel):
         if isinstance(user, ResolveInfo):
             user = user.context.user
         if settings.ROW_SECURITY and user.is_anonymous:
-            return queryset.filter(id=-1)
+            return queryset.filter(id=None)
         if settings.ROW_SECURITY:
             pass
         return queryset


### PR DESCRIPTION
Please merhe this fix, I've fixed this issue because there is no id as an integer, but UUID and "None" should be here in filtering when the user is anonymous etc.

Another pull requests related to this fix. openimis/openimis-be-calculation_py#2, https://github.com/openimis/openimis-be-policyholder_py/pull/10
https://github.com/openimis/openimis-be-calculation_py/pull/2