### PR TITLE
OFS-121: adding filters to CPB for filtering via calculation and product (both fields are in CP) 

### DIFF
--- a/contribution_plan/schema.py
+++ b/contribution_plan/schema.py
@@ -11,7 +11,6 @@ from contribution_plan.gql.gql_mutations.contribution_plan_mutations import Crea
     UpdateContributionPlanMutation, DeleteContributionPlanMutation, ReplaceContributionPlanMutation
 from contribution_plan.models import ContributionPlanBundle, ContributionPlan, ContributionPlanBundleDetails
 from core.schema import OrderedDjangoFilterConnectionField
-from core import prefix_filterset
 
 
 class Query(graphene.ObjectType):


### PR DESCRIPTION
In that pull request I want to add filters via "id" to ContributionPlanBundle (according to wiki page) through both "calculation" and "insurance product" (because as Rafal @rstencel mentioned me - in that filter we have "Select" type value).