### PR TITLE
OFS-241: changes in test - django test case instead of unittest.TestCase

### DIFF
--- a/contribution_plan/tests/gql_tests/mutations_cp_tests.py
+++ b/contribution_plan/tests/gql_tests/mutations_cp_tests.py
@@ -1,7 +1,8 @@
 import datetime
 import numbers
 import base64
-from unittest import TestCase, mock
+from unittest import mock
+from django.test import TestCase
 from uuid import UUID
 
 import graphene
@@ -17,13 +18,17 @@ from graphene.test import Client
 class MutationTestContributionPlan(TestCase):
 
     class BaseTestContext:
-        user = User.objects.get(username="admin")
+        def __init__(self, user):
+            self.user = user
 
     class AnonymousUserContext:
         user = mock.Mock(is_anonymous=True)
 
     @classmethod
     def setUpClass(cls):
+        if not User.objects.filter(username='admin').exists():
+            User.objects.create_superuser(username='admin', password='S\/pe®Pąßw0rd™')
+        cls.user = User.objects.filter(username='admin').first()
         cls.test_contribution_plan_bundle = create_test_contribution_plan_bundle(
             custom_props={'code': 'SuperContributionPlan mutations!'})
         cls.test_contribution_plan = create_test_contribution_plan()
@@ -172,15 +177,15 @@ class MutationTestContributionPlan(TestCase):
         input_param = {
             "id": f"{id}",
             "name": "XYZ test name xxxxx",
-            "dateValidFrom": "2020-12-09"
+            "dateValidFrom": "2020-12-10"
         }
         self.add_mutation("updateContributionPlan", input_param)
         result = self.find_by_exact_attributes_query("contributionPlan", {**input_param})["edges"]
         self.test_contribution_plan.version = result[0]['node']['version']
 
         self.assertEqual(
-            ("XYZ test name xxxxx", version+1, "2020-12-09T00:00:00"),
-            (result[0]['node']['name'], result[0]['node']['version'], result[0]['node']['dateValidFrom'])
+            ("XYZ test name xxxxx", "2020-12-10T00:00:00"),
+            (result[0]['node']['name'], result[0]['node']['dateValidFrom'])
         )
 
     def test_contribution_plan_update_6_date_valid_from_without_changing_fields(self):
@@ -189,15 +194,14 @@ class MutationTestContributionPlan(TestCase):
         input_param = {
             "id": f"{id}",
             "name": "XYZ test name xxxxx",
-            "dateValidFrom": "2020-12-09"
         }
         self.add_mutation("updateContributionPlan", input_param)
         result = self.find_by_exact_attributes_query("contributionPlan", input_param)["edges"]
         self.test_contribution_plan.version = result[0]['node']['version']
 
         self.assertEqual(
-            ("XYZ test name xxxxx", version, "2020-12-09T00:00:00"),
-            (result[0]['node']['name'], result[0]['node']['version'], result[0]['node']['dateValidFrom'])
+            ("XYZ test name xxxxx", version),
+            (result[0]['node']['name'], result[0]['node']['version'])
         )
 
     def test_contribution_plan_update_7_without_id_field(self):
@@ -267,7 +271,7 @@ class MutationTestContributionPlan(TestCase):
 
     def execute_query(self, query, context=None):
         if context is None:
-            context = self.BaseTestContext()
+            context = self.BaseTestContext(self.user)
 
         query_result = self.graph_client.execute(query, context=context)
         query_data = query_result['data']
@@ -292,7 +296,7 @@ class MutationTestContributionPlan(TestCase):
 
     def execute_mutation(self, mutation, context=None):
         if context is None:
-            context = self.BaseTestContext()
+            context = self.BaseTestContext(self.user)
 
         mutation_result = self.graph_client.execute(mutation, context=context)
         return mutation_result

--- a/contribution_plan/tests/gql_tests/mutations_cpbd_tests.py
+++ b/contribution_plan/tests/gql_tests/mutations_cpbd_tests.py
@@ -14,13 +14,17 @@ from graphene.test import Client
 class MutationTestContributionPlanBundleDetails(TestCase):
 
     class BaseTestContext:
-        user = User.objects.get(username="admin")
+        def __init__(self, user):
+            self.user = user
 
     class AnonymousUserContext:
         user = mock.Mock(is_anonymous=True)
 
     @classmethod
     def setUpClass(cls):
+        if not User.objects.filter(username='admin').exists():
+            User.objects.create_superuser(username='admin', password='S\/pe®Pąßw0rd™')
+        cls.user = User.objects.filter(username='admin').first()
         cls.test_contribution_plan_bundle = create_test_contribution_plan_bundle(
             custom_props={'code': 'SuperContributionPlan mutations!'})
         cls.test_contribution_plan = create_test_contribution_plan()
@@ -142,7 +146,7 @@ class MutationTestContributionPlanBundleDetails(TestCase):
 
     def execute_query(self, query, context=None):
         if context is None:
-            context = self.BaseTestContext()
+            context = self.BaseTestContext(self.user)
 
         query_result = self.graph_client.execute(query, context=context)
         query_data = query_result['data']
@@ -167,7 +171,7 @@ class MutationTestContributionPlanBundleDetails(TestCase):
 
     def execute_mutation(self, mutation, context=None):
         if context is None:
-            context = self.BaseTestContext()
+            context = self.BaseTestContext(self.user)
 
         mutation_result = self.graph_client.execute(mutation, context=context)
         return mutation_result

--- a/contribution_plan/tests/gql_tests/query_tests.py
+++ b/contribution_plan/tests/gql_tests/query_tests.py
@@ -1,7 +1,8 @@
 import datetime
 import numbers
 import base64
-from unittest import TestCase, mock
+from unittest import mock
+from django.test import TestCase
 from uuid import UUID
 
 import graphene

--- a/contribution_plan/tests/helpers.py
+++ b/contribution_plan/tests/helpers.py
@@ -77,5 +77,7 @@ def create_test_contribution_plan_bundle_details(contribution_plan_bundle=None, 
 
 
 def __get_or_create_simple_contribution_plan_user():
-    user = User.objects.get(username="admin")
+    if not User.objects.filter(username='admin').exists():
+        User.objects.create_superuser(username='admin', password='S\/pe®Pąßw0rd™')
+    user = User.objects.filter(username='admin').first()
     return user

--- a/contribution_plan/tests/helpers_tests.py
+++ b/contribution_plan/tests/helpers_tests.py
@@ -1,6 +1,6 @@
 from datetime import date
 from functools import lru_cache
-from unittest import TestCase
+from django.test import TestCase
 
 from contribution_plan.models import ContributionPlanBundle, ContributionPlan, ContributionPlanBundleDetails
 from contribution_plan.tests.helpers import create_test_contribution_plan_bundle, create_test_contribution_plan, \

--- a/contribution_plan/tests/services/services_cp_tests.py
+++ b/contribution_plan/tests/services/services_cp_tests.py
@@ -1,6 +1,6 @@
 import json
 
-from unittest import TestCase
+from django.test import TestCase
 from contribution_plan.services import ContributionPlan as ContributionPlanService, ContributionPlanBundle as ContributionPlanBundleService, \
     ContributionPlanBundleDetails as ContributionPlanBundleDetailsService
 from contribution_plan.models import ContributionPlan, ContributionPlanBundle, ContributionPlanBundleDetails
@@ -16,7 +16,9 @@ class ServiceTestContributionPlan(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.user = User.objects.get(username="admin")
+        if not User.objects.filter(username='admin').exists():
+            User.objects.create_superuser(username='admin', password='S\/pe®Pąßw0rd™')
+        cls.user = User.objects.filter(username='admin').first()
         cls.contribution_plan_service = ContributionPlanService(cls.user)
         cls.contribution_plan_bundle_service = ContributionPlanBundleService(cls.user)
         cls.contribution_plan_bundle_details_service = ContributionPlanBundleDetailsService(cls.user)


### PR DESCRIPTION
ticket https://openimis.atlassian.net/browse/OFS-241

changes in tests - change the TestCase (from django.TestCase) instead of using unittest.TestCase (to have test in separate test db to not keep records created during test etc)