### PR TITLE
Feature/otc 1099: filtering historical data

### DIFF
--- a/contribution_plan/schema.py
+++ b/contribution_plan/schema.py
@@ -93,45 +93,41 @@ class Query(graphene.ObjectType):
 
     def resolve_contribution_plan_bundle(self, info, **kwargs):
         if not info.context.user.has_perms(ContributionPlanConfig.gql_query_contributionplanbundle_perms):
-           raise PermissionError("Unauthorized")
+            raise PermissionError("Unauthorized")
 
         filters = append_validity_filter(**kwargs)
-        calculation = kwargs.get('calculation', None)
-        insurance_product = kwargs.get('insuranceProduct', None)
+        calculation = kwargs.get('calculation')
+        insurance_product = kwargs.get('insuranceProduct')
+        show_history = kwargs.get('showHistory')
         model = ContributionPlanBundle
-        if kwargs.get('showHistory', False):
+
+        if show_history:
             query = model.history.filter(*filters).all().as_instances()
         else:
             query = model.objects.filter(*filters).all()
 
-        # for ojb in ContributionPlanBundle.history.all().as_instances():
-        #     print(ContributionPlanBundle.objects.filter(id=ojb.pk))
-        lista_idkow = []
-        for i in query.values('id'):
-            print(i['id'])
-            lista_idkow.append(i['id'])
+        if show_history and (calculation or insurance_product):
+            filtered_details = ContributionPlanBundleDetails.objects
+            if calculation:
+                filtered_details = filtered_details.filter(
+                    contribution_plan__calculation=str(calculation)
+                ).values_list('contribution_plan_bundle', flat=True)
+            if insurance_product:
+                filtered_details = filtered_details.filter(
+                    contribution_plan__benefit_plan__id=insurance_product
+                ).values_list('contribution_plan_bundle', flat=True)
+            query = query.filter(id__in=filtered_details)
+        else:
+            if calculation:
+                query = query.filter(
+                    contributionplanbundledetails__contribution_plan__calculation=str(calculation)
+                ).distinct()
+            if insurance_product:
+                query = query.filter(
+                    contributionplanbundledetails__contribution_plan__benefit_plan__id=insurance_product
+                ).distinct()
 
-        query_cpbd = ContributionPlanBundleDetails.objects.filter(contribution_plan_bundle__in=lista_idkow)
-        print(query_cpbd)
-
-        if calculation:
-            query_cpbd = query_cpbd.filter(contribution_plan__calculation=str(calculation)).distinct()
-
-        if insurance_product:
-            query_cpbd = query_cpbd.filter(contribution_plan__benefit_plan__id=insurance_product).distinct()
-
-        lista_idkow2 = []
-        print("cos")
-        for i in query_cpbd.values('contribution_plan_bundle'):
-            print("tuuut", i)
-            lista_idkow2.append(i['contribution_plan_bundle'])
-
-        print(query_cpbd)
-        print(lista_idkow2)
-
-        query = ContributionPlanBundle.objects.filter(id__in=lista_idkow2)
-
-        return query.all()
+        return gql_optimizer.query(query.filter(*filters).all(), info)
 
     def resolve_contribution_plan_bundle_details(self, info, **kwargs):
         if not (info.context.user.has_perms(


### PR DESCRIPTION
Ticket:
https://openimis.atlassian.net/browse/OTC-1099

Changes:
- The historical ContributionPlanBundle (cpb) cannot be filtered by product and calculations. ContributionPlanBundleDetails (cpbd) is the related name defined in the ForeignKey field in the cpbd model, which is not supported by Django Simple History. When the query is set to be historical, the filtering is changed to use a separate query that is filtered by the second cpbd query.
- code refactor 