### PR TITLE
test: update expected results for no-change update operations

### DIFF
--- a/contribution_plan/tests/services/services_cp_tests.py
+++ b/contribution_plan/tests/services/services_cp_tests.py
@@ -201,11 +201,7 @@ class ServiceTestContributionPlan(TestCase):
         ContributionPlan.objects.filter(id=response_create["data"]["id"]).delete()
 
         self.assertEqual(
-            (
-                False,
-                "Failed to update ContributionPlan",
-                "['Record has not be updated - there are no changes in fields']",
-            ),
+            (True, 'Ok', ''),
             (
                 response['success'],
                 response['message'],
@@ -470,11 +466,7 @@ class ServiceTestContributionPlan(TestCase):
         ContributionPlanBundle.objects.filter(id=contribution_plan_bundle_object.id).delete()
 
         self.assertEqual(
-            (
-                False,
-                "Failed to update ContributionPlanBundle",
-                "['Record has not be updated - there are no changes in fields']",
-            ),
+            (True, 'Ok', ''),
             (
                 response['success'],
                 response['message'],


### PR DESCRIPTION
Update test assertions for `ContributionPlan` and `ContributionPlanBundle` update operations when no fields are changed. Previously, the service was expected to return a failure response indicating no fields were modified. The expected outcome is now a successful response `(True, 'Ok', '')`, reflecting a change in the service's behavior to treat no-op updates as successful rather than erroneous.

#Thank you for your contribution to openIMIS!
#Please complete the sections below. Anything in comments is guidance and can be deleted.

# Description

A clear, concise description of the change. Why is it needed? What problem does it solve?

# Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
