### PR TITLE
fix(gql): reject date_valid_to earlier than date_valid_from (OP-2073)

### DIFF
--- a/contribution_plan/gql/gql_mutations/contribution_plan_bundle_details_mutations.py
+++ b/contribution_plan/gql/gql_mutations/contribution_plan_bundle_details_mutations.py
@@ -8,6 +8,11 @@ from contribution_plan.gql.gql_mutations import ContributionPlanBundleDetailsInp
 from contribution_plan.models import ContributionPlanBundleDetails
 from django.utils.translation import gettext as _
 from django.core.exceptions import PermissionDenied
+from contribution_plan.gql.gql_mutations.validation import (
+    validate_date_validity_range,
+    validate_date_validity_range_on_create,
+    validate_date_validity_range_on_update,
+)
 
 
 class CreateContributionPlanBundleDetailsMutation(BaseHistoryModelCreateMutationMixin, BaseMutation):
@@ -23,6 +28,7 @@ class CreateContributionPlanBundleDetailsMutation(BaseHistoryModelCreateMutation
         super()._validate_mutation(user, **data)
         if not user.has_perms(ContributionPlanConfig.gql_mutation_create_contributionplanbundle_perms):
             raise PermissionDenied(_("unauthorized"))
+        validate_date_validity_range_on_create(cls._model, **data)
 
 
 
@@ -39,6 +45,7 @@ class UpdateContributionPlanBundleDetailsMutation(BaseHistoryModelUpdateMutation
         super()._validate_mutation(user, **data)
         if not user.has_perms(ContributionPlanConfig.gql_mutation_update_contributionplanbundle_perms):
             raise PermissionDenied(_("unauthorized"))
+        validate_date_validity_range_on_update(cls._model, **data)
 
 
 class DeleteContributionPlanBundleDetailsMutation(BaseHistoryModelDeleteMutationMixin, BaseDeleteMutation):
@@ -69,3 +76,4 @@ class ReplaceContributionPlanBundleDetailsMutation(BaseHistoryModelReplaceMutati
         super()._validate_mutation(user, **data)
         if not user.has_perms(ContributionPlanConfig.gql_mutation_replace_contributionplanbundle_perms):
             raise PermissionDenied(_("unauthorized"))
+        validate_date_validity_range(**data)

--- a/contribution_plan/gql/gql_mutations/contribution_plan_bundle_mutations.py
+++ b/contribution_plan/gql/gql_mutations/contribution_plan_bundle_mutations.py
@@ -24,6 +24,11 @@ from contribution_plan.services import (
 )
 from django.utils.translation import gettext as _
 from django.core.exceptions import PermissionDenied, ValidationError
+from contribution_plan.gql.gql_mutations.validation import (
+    validate_date_validity_range,
+    validate_date_validity_range_on_create,
+    validate_date_validity_range_on_update,
+)
 
 
 class CreateContributionPlanBundleMutation(BaseHistoryModelCreateMutationMixin, BaseMutation):
@@ -52,6 +57,7 @@ class CreateContributionPlanBundleMutation(BaseHistoryModelCreateMutationMixin, 
             raise PermissionDenied(_("unauthorized"))
         if ContributionPlanBundleService.check_unique_code(data['code']):
             raise ValidationError(_("mutation.cpb_code_duplicated"))
+        validate_date_validity_range_on_create(cls._model, **data)
 
 
 class UpdateContributionPlanBundleMutation(BaseHistoryModelUpdateMutationMixin, BaseMutation):
@@ -67,6 +73,7 @@ class UpdateContributionPlanBundleMutation(BaseHistoryModelUpdateMutationMixin, 
         super()._validate_mutation(user, **data)
         if not user.has_perms(ContributionPlanConfig.gql_mutation_update_contributionplanbundle_perms):
             raise PermissionDenied(_("unauthorized"))
+        validate_date_validity_range_on_update(cls._model, **data)
 
 
 class DeleteContributionPlanBundleMutation(BaseHistoryModelDeleteMutationMixin, BaseDeleteMutation):
@@ -156,3 +163,4 @@ class ReplaceContributionPlanBundleMutation(BaseHistoryModelReplaceMutationMixin
         super()._validate_mutation(user, **data)
         if not user.has_perms(ContributionPlanConfig.gql_mutation_replace_contributionplanbundle_perms):
             raise PermissionDenied(_("unauthorized"))
+        validate_date_validity_range(**data)

--- a/contribution_plan/gql/gql_mutations/contribution_plan_mutations.py
+++ b/contribution_plan/gql/gql_mutations/contribution_plan_mutations.py
@@ -13,6 +13,11 @@ from contribution_plan.gql.gql_mutations import ContributionPlanInputType, Contr
 from contribution_plan.models import ContributionPlan
 from django.utils.translation import gettext as _
 from django.core.exceptions import PermissionDenied, ValidationError
+from contribution_plan.gql.gql_mutations.validation import (
+    validate_date_validity_range,
+    validate_date_validity_range_on_create,
+    validate_date_validity_range_on_update,
+)
 
 
 class CreateContributionPlanMutation(BaseHistoryModelCreateMutationMixin, BaseMutation):
@@ -45,6 +50,7 @@ class CreateContributionPlanMutation(BaseHistoryModelCreateMutationMixin, BaseMu
             raise PermissionDenied(_("unauthorized"))
         if ContributionPlanService.check_unique_code(data['code']):
             raise ValidationError(_("mutation.cp_code_duplicated"))
+        validate_date_validity_range_on_create(cls._model, **data)
 
 
 class UpdateContributionPlanMutation(BaseHistoryModelUpdateMutationMixin, BaseMutation):
@@ -60,6 +66,7 @@ class UpdateContributionPlanMutation(BaseHistoryModelUpdateMutationMixin, BaseMu
         super()._validate_mutation(user, **data)
         if not user.has_perms(ContributionPlanConfig.gql_mutation_update_contributionplan_perms):
             raise PermissionDenied(_("unauthorized"))
+        validate_date_validity_range_on_update(cls._model, **data)
 
 
     @classmethod
@@ -112,3 +119,4 @@ class ReplaceContributionPlanMutation(BaseHistoryModelReplaceMutationMixin, Base
         super()._validate_mutation(user, **data)
         if not user.has_perms(ContributionPlanConfig.gql_mutation_replace_contributionplan_perms):
             raise PermissionDenied(_("unauthorized"))
+        validate_date_validity_range(**data)

--- a/contribution_plan/gql/gql_mutations/payment_plan_mutations.py
+++ b/contribution_plan/gql/gql_mutations/payment_plan_mutations.py
@@ -12,6 +12,11 @@ from contribution_plan.models import PaymentPlan
 from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext as _
+from contribution_plan.gql.gql_mutations.validation import (
+    validate_date_validity_range,
+    validate_date_validity_range_on_create,
+    validate_date_validity_range_on_update,
+)
 
 
 class CreatePaymentPlanMutation(BaseHistoryModelCreateMutationMixin, BaseMutation):
@@ -41,6 +46,7 @@ class CreatePaymentPlanMutation(BaseHistoryModelCreateMutationMixin, BaseMutatio
             raise ValidationError(_("mutation.authentication_required"))
         if PaymentPlanService.check_unique_code(data['code']):
             raise ValidationError(_("mutation.payment_plan_code_duplicated"))
+        validate_date_validity_range_on_create(cls._model, **data)
 
     class Input(PaymentPlanInputType):
         pass
@@ -59,6 +65,7 @@ class UpdatePaymentPlanMutation(BaseHistoryModelUpdateMutationMixin, BaseMutatio
 
         if PaymentPlanService.check_unique_code(data['code'], data['id']):
             raise ValidationError(_("mutation.payment_plan_code_duplicated"))
+        validate_date_validity_range_on_update(cls._model, **data)
 
     @classmethod
     def _mutate(cls, user, **data):
@@ -110,6 +117,7 @@ class ReplacePaymentPlanMutation(BaseHistoryModelReplaceMutationMixin, BaseRepla
         if type(user) is AnonymousUser or not user.id or not user.has_perms(
                 ContributionPlanConfig.gql_mutation_replace_paymentplan_perms):
             raise ValidationError(_("mutation.authentication_required"))
+        validate_date_validity_range(**data)
 
     class Input(PaymentPlanReplaceInputType):
         pass

--- a/contribution_plan/gql/gql_mutations/validation.py
+++ b/contribution_plan/gql/gql_mutations/validation.py
@@ -1,0 +1,31 @@
+import datetime
+
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext as _
+
+
+def __as_date(value):
+    return value.date() if isinstance(value, datetime.datetime) else value
+
+
+def validate_date_validity_range(**data):
+    date_valid_from = data.get('date_valid_from')
+    date_valid_to = data.get('date_valid_to')
+    if date_valid_from and date_valid_to and __as_date(date_valid_to) < __as_date(date_valid_from):
+        raise ValidationError(_("mutation.date_valid_to_before_date_valid_from"))
+
+
+def validate_date_validity_range_on_create(model, **data):
+    if data.get('date_valid_from') is None:
+        default_date_valid_from = model._meta.get_field('date_valid_from').get_default()
+        data = {**data, 'date_valid_from': default_date_valid_from}
+    validate_date_validity_range(**data)
+
+
+def validate_date_validity_range_on_update(model, **data):
+    if data.get('date_valid_from') is None:
+        stored_date_valid_from = model.objects.filter(id=data['id']).values_list(
+            'date_valid_from', flat=True
+        ).first()
+        data = {**data, 'date_valid_from': stored_date_valid_from}
+    validate_date_validity_range(**data)

--- a/contribution_plan/tests/__init__.py
+++ b/contribution_plan/tests/__init__.py
@@ -1,3 +1,4 @@
 from .helpers import *
 from .helpers_tests import *
 from .gql_tests import *
+from .validation_tests import *

--- a/contribution_plan/tests/gql_tests/mutations_cpb_tests.py
+++ b/contribution_plan/tests/gql_tests/mutations_cpb_tests.py
@@ -5,6 +5,7 @@ from unittest import mock
 from django.test import TestCase
 
 import graphene
+from core.models import MutationLog
 from core.models.openimis_graphql_test_case import openIMISGraphQLTestCase, BaseTestContext
 from contribution_plan.tests.helpers import *
 from core.test_helpers import create_test_interactive_user
@@ -163,6 +164,130 @@ class MutationTestContributionPlanBundle(openIMISGraphQLTestCase):
         }
         result_mutation = self.send_mutation("updateContributionPlanBundle", input_param, self.user_context.get_jwt(), follow=False, allow_exceptions=False)
         self.assertEqual(True, 'errors' in result_mutation)
+
+    def test_contribution_plan_bundle_create_date_valid_to_before_date_valid_from(self):
+        time_stamp = datetime.datetime.now()
+        code = "XYZ invalid range " + str(time_stamp)
+        input_param = {
+            "code": code,
+            "name": "XYZ test invalid range xyz - " + str(time_stamp),
+            "dateValidFrom": "2025-06-01",
+            "dateValidTo": "2025-05-01",
+        }
+        mutation_result = self.send_mutation(
+            "createContributionPlanBundle", input_param, self.user_context.get_jwt(),
+            follow=False, allow_exceptions=False
+        )
+        internal_id = mutation_result['data']['createContributionPlanBundle']['internalId']
+        mutation_log = MutationLog.objects.get(id=internal_id)
+
+        self.assertEqual(MutationLog.ERROR, mutation_log.status)
+        self.assertIn("date_valid_to_before_date_valid_from", mutation_log.error)
+        self.assertEqual(0, ContributionPlanBundle.objects.filter(code=code).count())
+
+    def test_contribution_plan_bundle_create_date_valid_to_after_date_valid_from(self):
+        time_stamp = datetime.datetime.now()
+        code = "XYZ valid range " + str(time_stamp)
+        input_param = {
+            "code": code,
+            "name": "XYZ test valid range xyz - " + str(time_stamp),
+            "dateValidFrom": "2025-05-01",
+            "dateValidTo": "2025-06-01",
+        }
+        mutation_result = self.add_mutation("createContributionPlanBundle", input_param)
+        node = mutation_result['data']['mutationLogs']['edges'][0]['node']
+
+        self.assertEqual(MutationLog.SUCCESS, node['status'])
+        self.assertEqual(1, ContributionPlanBundle.objects.filter(code=code).count())
+
+        ContributionPlanBundle.objects.filter(code=code).delete()
+
+    def test_contribution_plan_bundle_create_date_valid_to_without_date_valid_from(self):
+        time_stamp = datetime.datetime.now()
+        code = "XYZ default range " + str(time_stamp)
+        input_param = {
+            "code": code,
+            "name": "XYZ test default range xyz - " + str(time_stamp),
+            "dateValidTo": "2020-01-01",
+        }
+        mutation_result = self.send_mutation(
+            "createContributionPlanBundle", input_param, self.user_context.get_jwt(),
+            follow=False, allow_exceptions=False
+        )
+        internal_id = mutation_result['data']['createContributionPlanBundle']['internalId']
+        mutation_log = MutationLog.objects.get(id=internal_id)
+
+        self.assertEqual(MutationLog.ERROR, mutation_log.status)
+        self.assertIn("date_valid_to_before_date_valid_from", mutation_log.error)
+        self.assertEqual(0, ContributionPlanBundle.objects.filter(code=code).count())
+
+    def test_contribution_plan_bundle_create_date_valid_to_ahead_without_date_valid_from(self):
+        time_stamp = datetime.datetime.now()
+        code = "XYZ default valid range " + str(time_stamp)
+        date_valid_to = datetime.date.today() + datetime.timedelta(days=1)
+        input_param = {
+            "code": code,
+            "name": "XYZ test default valid range xyz - " + str(time_stamp),
+            "dateValidTo": f"{date_valid_to}",
+        }
+        mutation_result = self.add_mutation("createContributionPlanBundle", input_param)
+        node = mutation_result['data']['mutationLogs']['edges'][0]['node']
+
+        self.assertEqual(MutationLog.SUCCESS, node['status'])
+        self.assertEqual(1, ContributionPlanBundle.objects.filter(code=code).count())
+
+        ContributionPlanBundle.objects.filter(code=code).delete()
+
+    def test_contribution_plan_bundle_update_7_date_valid_to_before_stored_date_valid_from(self):
+        time_stamp = datetime.datetime.now()
+        contribution_plan_bundle = create_test_contribution_plan_bundle(
+            custom_props={
+                'code': "XYZ stored range " + str(time_stamp),
+                'date_valid_from': "2025-06-01",
+            }
+        )
+        input_param = {
+            "id": f"{contribution_plan_bundle.id}",
+            "dateValidTo": "2025-05-01",
+        }
+        mutation_result = self.send_mutation(
+            "updateContributionPlanBundle", input_param, self.user_context.get_jwt(),
+            follow=False, allow_exceptions=False
+        )
+        internal_id = mutation_result['data']['updateContributionPlanBundle']['internalId']
+        mutation_log = MutationLog.objects.get(id=internal_id)
+        contribution_plan_bundle.refresh_from_db()
+
+        self.assertEqual(MutationLog.ERROR, mutation_log.status)
+        self.assertIn("date_valid_to_before_date_valid_from", mutation_log.error)
+        self.assertIsNone(contribution_plan_bundle.date_valid_to)
+
+        contribution_plan_bundle.mutations.all().delete()
+        ContributionPlanBundle.objects.filter(id=contribution_plan_bundle.id).delete()
+
+    def test_contribution_plan_bundle_update_8_date_valid_to_after_stored_date_valid_from(self):
+        time_stamp = datetime.datetime.now()
+        contribution_plan_bundle = create_test_contribution_plan_bundle(
+            custom_props={
+                'code': "XYZ stored valid range " + str(time_stamp),
+                'date_valid_from': "2025-05-01",
+            }
+        )
+        input_param = {
+            "id": f"{contribution_plan_bundle.id}",
+            "dateValidTo": "2025-06-01",
+        }
+        mutation_result = self.add_mutation("updateContributionPlanBundle", input_param)
+        node = mutation_result['data']['mutationLogs']['edges'][0]['node']
+        contribution_plan_bundle.refresh_from_db()
+
+        self.assertEqual(MutationLog.SUCCESS, node['status'])
+        self.assertEqual(
+            datetime.date(2025, 6, 1), contribution_plan_bundle.date_valid_to.date()
+        )
+
+        contribution_plan_bundle.mutations.all().delete()
+        ContributionPlanBundle.objects.filter(id=contribution_plan_bundle.id).delete()
 
     def find_by_id_query(self, query_type, id, context=None):
         query = F'''

--- a/contribution_plan/tests/validation_tests.py
+++ b/contribution_plan/tests/validation_tests.py
@@ -1,0 +1,94 @@
+import datetime
+
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from contribution_plan.gql.gql_mutations.validation import (
+    validate_date_validity_range,
+    validate_date_validity_range_on_create,
+    validate_date_validity_range_on_update,
+)
+from contribution_plan.models import ContributionPlanBundle
+from contribution_plan.tests.helpers import create_test_contribution_plan_bundle
+
+
+class ValidationTestDateValidityRange(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(ValidationTestDateValidityRange, cls).setUpClass()
+        cls.test_contribution_plan_bundle = create_test_contribution_plan_bundle(
+            custom_props={
+                'code': "Validation range " + str(datetime.datetime.now()),
+                'date_valid_from': datetime.datetime(2025, 6, 1),
+            }
+        )
+
+    def test_date_valid_to_after_date_valid_from(self):
+        validate_date_validity_range(
+            date_valid_from=datetime.date(2025, 5, 1),
+            date_valid_to=datetime.date(2025, 6, 1),
+        )
+
+    def test_date_valid_to_before_date_valid_from(self):
+        with self.assertRaises(ValidationError) as context:
+            validate_date_validity_range(
+                date_valid_from=datetime.date(2025, 6, 1),
+                date_valid_to=datetime.date(2025, 5, 1),
+            )
+        self.assertIn("date_valid_to_before_date_valid_from", str(context.exception))
+
+    def test_equal_dates_are_accepted(self):
+        validate_date_validity_range(
+            date_valid_from=datetime.date(2025, 6, 1),
+            date_valid_to=datetime.date(2025, 6, 1),
+        )
+
+    def test_date_from_model_and_date_from_input_are_comparable(self):
+        with self.assertRaises(ValidationError):
+            validate_date_validity_range(
+                date_valid_from=datetime.datetime(2025, 6, 1, 14, 30),
+                date_valid_to=datetime.date(2025, 5, 1),
+            )
+
+    def test_without_date_valid_to_nothing_is_validated(self):
+        validate_date_validity_range(date_valid_from=datetime.date(2025, 6, 1))
+
+    def test_create_without_date_valid_from_uses_model_default(self):
+        with self.assertRaises(ValidationError) as context:
+            validate_date_validity_range_on_create(
+                ContributionPlanBundle, date_valid_to=datetime.date(2020, 1, 1)
+            )
+        self.assertIn("date_valid_to_before_date_valid_from", str(context.exception))
+
+    def test_create_without_date_valid_from_accepts_future_date_valid_to(self):
+        validate_date_validity_range_on_create(
+            ContributionPlanBundle,
+            date_valid_to=datetime.date.today() + datetime.timedelta(days=1),
+        )
+
+    def test_update_without_date_valid_from_uses_stored_value(self):
+        with self.assertRaises(ValidationError) as context:
+            validate_date_validity_range_on_update(
+                ContributionPlanBundle,
+                id=self.test_contribution_plan_bundle.id,
+                date_valid_to=datetime.date(2025, 5, 1),
+            )
+        self.assertIn("date_valid_to_before_date_valid_from", str(context.exception))
+
+    def test_update_with_explicit_none_date_valid_from_uses_stored_value(self):
+        with self.assertRaises(ValidationError):
+            validate_date_validity_range_on_update(
+                ContributionPlanBundle,
+                id=self.test_contribution_plan_bundle.id,
+                date_valid_from=None,
+                date_valid_to=datetime.date(2025, 5, 1),
+            )
+
+    def test_update_with_date_valid_from_in_payload_ignores_stored_value(self):
+        validate_date_validity_range_on_update(
+            ContributionPlanBundle,
+            id=self.test_contribution_plan_bundle.id,
+            date_valid_from=datetime.date(2025, 1, 1),
+            date_valid_to=datetime.date(2025, 5, 1),
+        )


### PR DESCRIPTION
# Description

`ContributionPlan`, `ContributionPlanBundle`, `ContributionPlanBundleDetails` and
`PaymentPlan` could be saved with `date_valid_to` earlier than `date_valid_from`
(OP-2073). The create, update and replace mutations of all four models now reject such a
range with `mutation.date_valid_to_before_date_valid_from`.

The rule lives in a new module-level validator,
`contribution_plan/gql/gql_mutations/validation.py`, called explicitly from every
`_validate_mutation` after the permission checks. It is a plain function rather than a
mixin on purpose: four classes in `payment_plan_mutations.py` do not call
`super()._validate_mutation()`, so a `super()`-based mixin would silently skip them.

Validating the incoming payload alone is not enough, because the write layer fills in
values the payload does not carry. The validator therefore checks the values that
actually reach the database:

- **create** — a missing `date_valid_from` falls back to the model default
  (`HistoryBusinessModel.date_valid_from` is `DateTimeField(default=now)`), so a payload
  carrying only `date_valid_to` no longer bypasses the rule;
- **update** — a missing `date_valid_from` is read from the stored row, because
  `BaseHistoryModelUpdateMutationMixin._mutate` applies only the fields present in the
  payload on top of the existing object;
- **`date_valid_to` deliberately has no fallback** — the same `_mutate` treats its
  absence as "clear the end date", so backfilling it would change that semantics;
- input dates (`graphene.Date`) and stored values (`DateTimeField`) are normalised before
  comparison; without that the comparison raises `TypeError`, which the generic mutation
  error handler surfaces as `Failed to process ... mutation`.

Equal dates are accepted (a zero-length range is treated as valid).

Two related defects were found while working on this and are **not** addressed here:

1. `HistoryBusinessModel._update_replaced_entity` (in `core`) sets the replaced row's
   `date_valid_to` to the new entity's `date_valid_from` without comparing it to the
   replaced row's own `date_valid_from`, so replacing an entity with an earlier
   `date_valid_from` leaves the *previous* row with an inverted range. The new entity is
   validated correctly; fixing the replaced one belongs in `core`.
2. `UpdatePaymentPlanMutation._validate_mutation` reads `data['code']` unconditionally
   although `code` is optional in `PaymentPlanUpdateInputType`, so an update payload
   without `code` fails with `KeyError` before any date validation runs. Pre-existing.

Happy to open separate issues for both if that is preferred.

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [x] External reference (e.g., Jira): https://openimis.atlassian.net/browse/OP-2073

## Demo

Backend-only change, no UI. Reproduction of the reported behaviour and the result after
the fix, via the GraphQL API:

Before — accepted and stored:

```
mutation {
  createContributionPlanBundle(input: {
    code: "DEMO", name: "Demo", dateValidFrom: "2025-06-01", dateValidTo: "2025-05-01"
  }) { internalId }
}

```

After — the mutation log ends in ERROR with
mutation.date_valid_to_before_date_valid_from, and no row is created. The same holds
for a payload carrying only dateValidTo (create), and for an update that sends only
dateValidTo against a stored date_valid_from.

Test run:

python manage.py test --keepdb contribution_plan
Ran 68 tests in 6.6s
OK

(52 tests before this change.)

Checklist

- [x] Unit tests added/modified

- contribution_plan/tests/validation_tests.py (new) covers the validator directly:
valid and inverted ranges, equal dates, missing date_valid_to, mixed date/
datetime, the model default on create, and the stored-value fallback on update
(missing key, explicit None, value supplied in the payload).
contribution_plan/tests/gql_tests/mutations_cpb_tests.py covers the create and update
paths end to end, asserting the mutation log status, the translation key and the state
of the database. Each new negative test was verified to fail when its guard is reverted.
- [ ] I18n / translation handled

- The message key mutation.date_valid_to_before_date_valid_from follows the existing
convention of this module, but the .po entries live in openimis-be_py
(openIMIS/locale/{en,fr}/LC_MESSAGES/django.po), where the module's other keys are
registered. This needs a companion PR in that repository; until then the raw key is
shown, exactly as it currently is for mutation.cpb_code_duplicated.